### PR TITLE
Improve site layout with dark mode and about page

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@
 3. Generate an application key using `php artisan key:generate`.
 4. Start your preferred local server (such as XAMPP) and run `php artisan serve`.
 
+## Features
+
+- Layout responsivo criado com Tailwind CSS
+- Modo escuro com alternância na barra de navegação
+- Página "Sobre" com informações da empresa
+
 ## About Laravel
 
 Laravel is a web application framework with expressive, elegant syntax. We believe development must be an enjoyable and creative experience to be truly fulfilling. Laravel takes the pain out of development by easing common tasks used in many web projects, such as:

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -5,3 +5,19 @@ import Alpine from 'alpinejs';
 window.Alpine = Alpine;
 
 Alpine.start();
+
+window.toggleTheme = function () {
+    const html = document.documentElement;
+    if (html.classList.contains('dark')) {
+        html.classList.remove('dark');
+        localStorage.setItem('theme', 'light');
+    } else {
+        html.classList.add('dark');
+        localStorage.setItem('theme', 'dark');
+    }
+};
+
+// Initialize theme based on saved preference
+if (localStorage.getItem('theme') === 'dark') {
+    document.documentElement.classList.add('dark');
+}

--- a/resources/views/about.blade.php
+++ b/resources/views/about.blade.php
@@ -1,0 +1,12 @@
+<x-app-layout>
+    <div class="py-12 bg-white dark:bg-gray-800">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <h1 class="text-4xl font-bold text-center text-gray-800 dark:text-white mb-8">Sobre a FinanceCorp</h1>
+            <div class="bg-white dark:bg-gray-700 overflow-hidden shadow-sm sm:rounded-lg p-6 text-gray-700 dark:text-gray-200">
+                <p class="mb-4">A FinanceCorp oferece soluções completas de controle financeiro para empresas de todos os tamanhos. Nosso objetivo é simplificar a gestão de despesas, receitas e planejamento financeiro.</p>
+                <p class="mb-4">Nossa plataforma é totalmente responsiva e conta com integrações em tempo real para garantir que você tenha sempre os dados mais atualizados.</p>
+                <p class="mb-4">Entre em contato conosco para saber mais sobre nossos planos e serviços.</p>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -15,7 +15,7 @@
         @vite(['resources/css/app.css', 'resources/js/app.js'])
     </head>
     <body class="font-sans antialiased">
-        <div class="min-h-screen bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500">
+        <div class="min-h-screen bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 dark:from-gray-800 dark:via-gray-900 dark:to-black">
             @include('layouts.navigation')
 
             <!-- Page Heading -->

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -15,7 +15,7 @@
         @vite(['resources/css/app.css', 'resources/js/app.js'])
     </head>
     <body class="font-sans text-gray-900 antialiased">
-        <div class="min-h-screen flex flex-col items-center justify-center bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 py-6">
+        <div class="min-h-screen flex flex-col items-center justify-center bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 dark:from-gray-800 dark:via-gray-900 dark:to-black py-6">
             <a href="/" class="text-white text-4xl font-bold">
                 FinanceCorp
             </a>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -1,4 +1,4 @@
-<nav x-data="{ open: false }" class="bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 text-white">
+<nav x-data="{ open: false }" class="bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 dark:from-gray-800 dark:via-gray-900 dark:to-black text-white">
     <!-- Primary Navigation Menu -->
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex justify-between h-16">
@@ -15,11 +15,20 @@
                     <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                         {{ __('Dashboard') }}
                     </x-nav-link>
+                    <x-nav-link :href="route('about')" :active="request()->routeIs('about')">
+                        {{ __('Sobre') }}
+                    </x-nav-link>
                 </div>
             </div>
 
-            <!-- Settings Dropdown -->
-            <div class="hidden sm:flex sm:items-center sm:ms-6">
+            <div class="hidden sm:flex sm:items-center sm:ms-6 space-x-4">
+                <button onclick="toggleTheme()" class="p-2 rounded-md hover:bg-purple-600 transition" title="Alternar tema">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                        <path d="M10 2a.75.75 0 01.75.75v1.5a.75.75 0 01-1.5 0v-1.5A.75.75 0 0110 2zM10 14a4 4 0 100-8 4 4 0 000 8zM16.25 10a.75.75 0 01.75-.75h1.5a.75.75 0 010 1.5h-1.5a.75.75 0 01-.75-.75zM2 9.25a.75.75 0 100 1.5h1.5a.75.75 0 100-1.5H2zM14.784 5.216a.75.75 0 011.06 1.06l-1.061 1.062a.75.75 0 11-1.06-1.061l1.06-1.061zM5.216 14.784a.75.75 0 011.06 0l1.062 1.061a.75.75 0 11-1.061 1.06l-1.06-1.06a.75.75 0 010-1.061zM15.844 15.844a.75.75 0 00-1.06-1.06l-1.062 1.061a.75.75 0 101.062 1.061l1.06-1.062zM6.278 4.156a.75.75 0 10-1.06-1.06L4.156 4.156a.75.75 0 101.061 1.061l1.061-1.06z" />
+                    </svg>
+                </button>
+
+                <!-- Settings Dropdown -->
                 <x-dropdown align="right" width="48">
                     <x-slot name="trigger">
                         <button class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-white bg-transparent hover:text-gray-200 focus:outline-none transition ease-in-out duration-150">
@@ -65,10 +74,13 @@
     </div>
 
     <!-- Responsive Navigation Menu -->
-    <div :class="{'block': open, 'hidden': ! open}" class="hidden sm:hidden bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 text-white">
+    <div :class="{'block': open, 'hidden': ! open}" class="hidden sm:hidden bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 dark:from-gray-800 dark:via-gray-900 dark:to-black text-white">
         <div class="pt-2 pb-3 space-y-1">
             <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                 {{ __('Dashboard') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('about')" :active="request()->routeIs('about')">
+                {{ __('Sobre') }}
             </x-responsive-nav-link>
         </div>
 

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,5 +1,5 @@
 <x-guest-layout>
-    <div class="bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 py-20 text-white text-center">
+    <div class="bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 dark:from-gray-800 dark:via-gray-900 dark:to-black py-20 text-white text-center">
         <h1 class="text-5xl font-bold mb-4">Bem-vindo à FinanceCorp</h1>
         <p class="max-w-3xl mx-auto text-lg">
             A FinanceCorp é especialista em soluções de controle financeiro para empresas de todos os tamanhos.
@@ -7,10 +7,10 @@
         </p>
     </div>
 
-    <div class="max-w-4xl mx-auto my-12 bg-white shadow-md rounded-lg p-6">
+    <div class="max-w-4xl mx-auto my-12 bg-white dark:bg-gray-800 shadow-md rounded-lg p-6">
         <h2 class="text-2xl font-semibold mb-4 text-center">Ações em tempo real</h2>
-        <table class="min-w-full divide-y divide-gray-200">
-            <thead class="bg-gray-50">
+        <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+            <thead class="bg-gray-50 dark:bg-gray-700">
                 <tr>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Ação</th>
                     <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Preço</th>
@@ -19,7 +19,7 @@
                     <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Baixa</th>
                 </tr>
             </thead>
-            <tbody class="bg-white divide-y divide-gray-200">
+            <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
                 @forelse ($stocks as $stock)
                     <tr>
                         <td class="px-6 py-4 whitespace-nowrap font-medium">{{ $stock['name'] }}</td>

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,8 @@ use App\Http\Controllers\WelcomeController;
 
 Route::get('/', [WelcomeController::class, 'index']);
 
+Route::view('/about', 'about')->name('about');
+
 Route::get('/dashboard', function () {
     return view('dashboard');
 })->middleware(['auth', 'verified'])->name('dashboard');

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,7 @@ import forms from '@tailwindcss/forms';
 
 /** @type {import('tailwindcss').Config} */
 export default {
+    darkMode: 'class',
     content: [
         './vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php',
         './storage/framework/views/*.php',


### PR DESCRIPTION
## Summary
- add an About page
- add dark mode toggle and responsive color themes
- link new page in navigation menus
- document features in README

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6859ff826d308321927933755b9e58f9