### PR TITLE
Add market page with TradingView widget

### DIFF
--- a/app/Http/Controllers/MarketController.php
+++ b/app/Http/Controllers/MarketController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\View\View;
+
+class MarketController extends Controller
+{
+    public function index(): View
+    {
+        return view('market');
+    }
+}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -15,12 +15,12 @@
         @vite(['resources/css/app.css', 'resources/js/app.js'])
     </head>
     <body class="font-sans antialiased">
-        <div class="min-h-screen bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 dark:from-gray-800 dark:via-gray-900 dark:to-black">
+        <div class="min-h-screen bg-gradient-to-br from-gray-700 via-gray-900 to-black text-white">
             @include('layouts.navigation')
 
             <!-- Page Heading -->
             @isset($header)
-                <header class="bg-white bg-opacity-80 shadow">
+                <header class="bg-white/30 dark:bg-gray-900/40 backdrop-blur shadow">
                     <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
                         {{ $header }}
                     </div>

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -15,12 +15,12 @@
         @vite(['resources/css/app.css', 'resources/js/app.js'])
     </head>
     <body class="font-sans text-gray-900 antialiased">
-        <div class="min-h-screen flex flex-col items-center justify-center bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 dark:from-gray-800 dark:via-gray-900 dark:to-black py-6">
+        <div class="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-gray-700 via-gray-900 to-black text-white py-6">
             <a href="/" class="text-white text-4xl font-bold">
                 FinanceCorp
             </a>
 
-            <div class="w-full sm:max-w-md mt-6 px-6 py-4 bg-white shadow-md overflow-hidden sm:rounded-lg">
+            <div class="w-full sm:max-w-md mt-6 px-6 py-4 bg-white/20 dark:bg-gray-800/40 backdrop-blur-md shadow-md overflow-hidden sm:rounded-lg">
                 {{ $slot }}
             </div>
         </div>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -1,4 +1,4 @@
-<nav x-data="{ open: false }" class="bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 dark:from-gray-800 dark:via-gray-900 dark:to-black text-white">
+<nav x-data="{ open: false }" class="backdrop-blur bg-white/30 dark:bg-gray-900/30 border-b border-white/10 dark:border-gray-700 text-white">
     <!-- Primary Navigation Menu -->
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex justify-between h-16">
@@ -17,6 +17,9 @@
                     </x-nav-link>
                     <x-nav-link :href="route('about')" :active="request()->routeIs('about')">
                         {{ __('Sobre') }}
+                    </x-nav-link>
+                    <x-nav-link :href="route('market')" :active="request()->routeIs('market')">
+                        {{ __('Mercado') }}
                     </x-nav-link>
                 </div>
             </div>
@@ -81,6 +84,9 @@
             </x-responsive-nav-link>
             <x-responsive-nav-link :href="route('about')" :active="request()->routeIs('about')">
                 {{ __('Sobre') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('market')" :active="request()->routeIs('market')">
+                {{ __('Mercado') }}
             </x-responsive-nav-link>
         </div>
 

--- a/resources/views/market.blade.php
+++ b/resources/views/market.blade.php
@@ -1,0 +1,35 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-2xl text-white leading-tight">
+            {{ __('Mercado') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
+            <div class="bg-white/50 dark:bg-gray-800/70 backdrop-blur-md rounded-lg shadow p-6">
+                <div id="tradingview-widget" style="height:600px"></div>
+            </div>
+        </div>
+    </div>
+
+    <script type="text/javascript" src="https://s3.tradingview.com/tv.js"></script>
+    <script type="text/javascript">
+        new TradingView.widget({
+            "container_id": "tradingview-widget",
+            "autosize": true,
+            "symbol": "BMFBOVESPA:IBOV",
+            "interval": "60",
+            "timezone": "Etc/UTC",
+            "theme": "dark",
+            "style": "1",
+            "locale": "br",
+            "enable_publishing": false,
+            "hide_top_toolbar": true,
+            "hide_legend": false,
+            "save_image": false,
+            "studies": [],
+            "support_host": "https://www.tradingview.com"
+        });
+    </script>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,10 +3,13 @@
 use App\Http\Controllers\ProfileController;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\WelcomeController;
+use App\Http\Controllers\MarketController;
 
 Route::get('/', [WelcomeController::class, 'index']);
 
 Route::view('/about', 'about')->name('about');
+
+Route::get('/market', [MarketController::class, 'index'])->name('market');
 
 Route::get('/dashboard', function () {
     return view('dashboard');


### PR DESCRIPTION
## Summary
- create `MarketController`
- add `/market` route with a new page showing a TradingView chart
- update navigation links to include **Mercado** page
- apply dark glassmorphism style to layouts

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_b_685a04cae9e88321a7edbacffc8f5897